### PR TITLE
【React 機能実装】User登録機能

### DIFF
--- a/frontend/src/apis/users.js
+++ b/frontend/src/apis/users.js
@@ -1,14 +1,31 @@
 import axios from "axios";
-import { usersIndex, user } from "../urls/index";
+import { users, user } from "../urls/index";
 
 export const fetchUsersIndex = () => {
   return axios
-    .get(usersIndex)
+    .get(users)
     .then((response) => {
       return response.data;
     })
     .catch((error) => {
       throw error;
+    });
+};
+
+export const postUser = (params) => {
+  const { formData } = params;
+
+  return axios
+    .post(users, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    })
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error) => {
+      return error.response.data;
     });
 };
 

--- a/frontend/src/components/presentations/UserCreateDialog.jsx
+++ b/frontend/src/components/presentations/UserCreateDialog.jsx
@@ -1,0 +1,143 @@
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Stack,
+  Alert,
+  Avatar,
+  TextField,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Button,
+} from "@mui/material";
+import CreateIcon from '@mui/icons-material/Create';
+import PropTypes from 'prop-types';
+
+export const UserCreateDialog = ({
+  isOpen,
+  errors,
+  preview,
+  onClose,
+  onChangeUserName,
+  onChangeUserEmail,
+  onChangeUserPassword,
+  onChangeUserPasswordConfirmation,
+  onChangeUserAdmin,
+  onChangeUserGuest,
+  onChangeUserProfile,
+  onChangeUserAvatar,
+  onClick,
+}) => {
+  return (
+    <Dialog open={isOpen} onClose={onClose}>
+    {errors &&
+      <Stack>
+        {errors.map((error) =>
+        <Alert key={error} severity="error">{error}</Alert>
+        )}
+      </Stack>
+    }
+      <DialogTitle>
+        <Stack>ユーザー登録</Stack>
+      </DialogTitle>
+      <DialogContent>
+        <Stack direction="row">
+          <FormControl>
+            <FormLabel>アバター</FormLabel>
+            <input onChange={onChangeUserAvatar} type="file" accept=".png, .jpg, .jpeg, .gif" />
+          </FormControl>
+          <FormControl>
+            <FormLabel>preview</FormLabel>
+            <Avatar alt="preview" src={preview} style={{marginLeft: "50%"}} />
+          </FormControl>
+        </Stack>
+        <TextField
+          onChange={onChangeUserName}
+          label="ユーザー名"
+          type="text"
+          fullWidth
+          variant="outlined"
+          margin="normal"
+        />
+        <TextField
+          onChange={onChangeUserEmail}
+          label="メールアドレス"
+          type="email"
+          fullWidth
+          variant="outlined"
+          margin="normal"
+        />
+        <TextField
+          onChange={onChangeUserPassword}
+          label="パスワード"
+          type="password"
+          fullWidth
+          variant="outlined"
+          margin="normal"
+        />
+        <TextField
+          onChange={onChangeUserPasswordConfirmation}
+          label="パスワード（確認）"
+          type="password"
+          fullWidth
+          variant="outlined"
+          margin="normal"
+        />
+        <FormControl>
+          <FormLabel>管理者権限</FormLabel>
+          <RadioGroup onChange={onChangeUserAdmin} row>
+            <FormControlLabel value="false" control={<Radio />} label="なし" />
+            <FormControlLabel value="true" control={<Radio />} label="あり" />
+          </RadioGroup>
+        </FormControl>
+        <FormControl>
+          <FormLabel>ゲスト権限</FormLabel>
+          <RadioGroup onChange={onChangeUserGuest} row>
+            <FormControlLabel value="false" control={<Radio />} label="なし" />
+            <FormControlLabel value="true" control={<Radio />} label="あり" />
+          </RadioGroup>
+        </FormControl>
+        <TextField
+          onChange={onChangeUserProfile}
+          label="プロフィール"
+          type="text"
+          multiline
+          fullWidth
+          variant="outlined"
+          margin="normal"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          type="submit"
+          onClick={onClick}
+          variant="outlined"
+          startIcon={<CreateIcon />}
+        >
+          ユーザー登録する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+UserCreateDialog.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  preview: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onClose: PropTypes.func.isRequired,
+  onChangeUserName: PropTypes.func.isRequired,
+  onChangeUserEmail: PropTypes.func.isRequired,
+  onChangeUserPassword: PropTypes.func.isRequired,
+  onChangeUserPasswordConfirmation: PropTypes.func.isRequired,
+  onChangeUserAdmin: PropTypes.func.isRequired,
+  onChangeUserGuest: PropTypes.func.isRequired,
+  onChangeUserProfile: PropTypes.func.isRequired,
+  onChangeUserAvatar: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -1,5 +1,5 @@
 const DEFAULT_API_LOCALHOST = "http://localhost:3000/api/v1";
 
-export const usersIndex = `${DEFAULT_API_LOCALHOST}/admin/users`;
+export const users = `${DEFAULT_API_LOCALHOST}/admin/users`;
 export const user = (userId) =>
   `${DEFAULT_API_LOCALHOST}/admin/users/${userId}`;


### PR DESCRIPTION
41. 
    
    ## 概要
    
    User登録機能を実装する．
    
    User登録モーダルを作成する．
    
    登録完了後，登録したユーザーのUser詳細モーダルを開く．
    
    ## 目的
    
    Userを登録できるようにする．
    
    ## 実装タスク
    
    - [ ]  Users.jsx
        - [ ]  登録モーダルを追加する．
    - [ ]  登録モーダル用コンポーネントを作成．
    - [ ]  api/users.js：postメソッドで削除対象をRailsに送信．
    - [ ]  コントローラ
        - [ ]  createアクション
            
            httpレスポンスコードをokにして，Reactにメッセージデータを送信．