### PR TITLE
【React 機能実装】投稿へのReply機能を実装 #51

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -34,6 +34,7 @@ module Api
         maps = posts_maps.compact_blank.uniq
         #! gon.places = Map.where(id: maps.map(&:id))
 
+        #! 以下，暫定的に全データを送信している．開発が進んだら，適切に絞り込む．
         postss = Post.all.order(created_at: :desc)
         userss = User.all
         mapss = Map.all
@@ -42,6 +43,8 @@ module Api
         favoritess = current_user.favorites
         favoritess_all = Favorite.all #! 閲覧可能なpostに対応するfavoriteレコードだけ抽出すること．
         bookmarkss = current_user.bookmarks
+        repliess = Reply.all
+
         #! users_with_avatarの取得はモデルメソッドに切り出す．
         users_with_avatar = userss.map do |user|
           if user.user_avatar.attached?
@@ -68,6 +71,7 @@ module Api
           favorites: favoritess,
           favorites_all: favoritess_all,
           bookmarks: bookmarkss,
+          replies: repliess,
         }, status: :ok
       end
 

--- a/app/controllers/api/v1/replies_controller.rb
+++ b/app/controllers/api/v1/replies_controller.rb
@@ -2,24 +2,23 @@ module Api
   module V1
     class RepliesController < ApplicationController
       def create
-        @reply = Reply.create(reply_params)
-        @replies = Reply.where(post_id: @reply.post_id)
-        @reply.create_reply_notice(@replies, current_user)
-        flash[:info] = "リプライしました！"
-        redirect_to request.referer
+        Reply.create(reply_params)
+        # @replies = Reply.where(post_id: @reply.post_id)
+        #! @reply.create_reply_notice(@replies, current_user)
+        render json: { message: "コメントしました！" }, status: :created
       end
 
       def destroy
-        @reply = Reply.find(params[:id])
-        @reply.destroy
-        flash[:warning] = "リプライを削除しました．"
-        redirect_to request.referer
+        reply = Reply.find(params[:id])
+        reply.destroy
+        render json: { message: "コメントを削除しました．" }, status: :ok
       end
 
       private
 
       def reply_params
-        params.require(:reply).permit(:reply).merge(user_id: current_user.id, post_id: params[:post_id])
+        params.permit(:reply).merge(user_id: current_user.id, post_id: params[:post_id])
+        # params.require(:reply).permit(:reply).merge(user_id: current_user.id, post_id: params[:post_id])
       end
     end
   end

--- a/frontend/src/apis/replies.js
+++ b/frontend/src/apis/replies.js
@@ -1,0 +1,35 @@
+import axios from "axios";
+import { replies, reply } from "../urls/index";
+
+export const postReply = (params) => {
+  const { postId, formData } = params;
+
+  return axios
+    .post(replies(postId), formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+      withCredentials: true,
+    })
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error) => {
+      return error.response.data;
+    });
+};
+
+export const deleteReply = (params) => {
+  const { postId, replyId } = params;
+
+  return axios
+    .delete(reply(postId, replyId), {
+      withCredentials: true,
+    })
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error) => {
+      throw error;
+    });
+};

--- a/frontend/src/components/presentations/PostCard.jsx
+++ b/frontend/src/components/presentations/PostCard.jsx
@@ -57,6 +57,7 @@ export const PostCard = (props) => {
     favoriteState,
     favoritesCount,
     bookmarkState,
+    repliesCount,
     onClickPost,
     onClickUser,
     onClickFavorite,
@@ -150,9 +151,17 @@ export const PostCard = (props) => {
           checked={bookmarkState}
           onChange={onClickBookmark}
         />
-        <IconButton aria-label="chat">
-          <ChatIcon />
-        </IconButton>
+        {repliesCount > 0 ?
+          <Badge badgeContent={repliesCount} color="secondary">
+            <IconButton aria-label="chat" style={{color: "green"}}>
+              <ChatIcon onClick={onClickPost} />
+            </IconButton>
+          </Badge>
+        :
+          <IconButton aria-label="chat">
+            <ChatIcon onClick={onClickPost} />
+          </IconButton>
+        }
       </CardActions>
     </Card>
   );
@@ -192,6 +201,7 @@ PostCard.propTypes = {
   favoriteState: PropTypes.bool.isRequired,
   favoritesCount: PropTypes.number.isRequired,
   bookmarkState: PropTypes.bool.isRequired,
+  repliesCount: PropTypes.number.isRequired,
   onClickPost: PropTypes.func.isRequired,
   onClickUser: PropTypes.func.isRequired,
   onClickFavorite: PropTypes.func.isRequired,

--- a/frontend/src/components/presentations/PostCreateDialog.jsx
+++ b/frontend/src/components/presentations/PostCreateDialog.jsx
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
 export const PostCreateDialog = ({
   isOpen,
   newPostImagesPreviews,
+  // memorableDay,
   errors,
   onClose,
   onChangeMemorableDay,
@@ -126,6 +127,7 @@ export const PostCreateDialog = ({
         <TextField
           onChange={onChangeMemorableDay}
           label="いつ？"
+          // value={memorableDay}
           type="date"
           fullWidth
           variant="outlined"
@@ -184,6 +186,7 @@ export const PostCreateDialog = ({
 PostCreateDialog.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   newPostImagesPreviews: PropTypes.arrayOf(PropTypes.string).isRequired,
+  // memorableDay: PropTypes.string.isRequired,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
   onClose: PropTypes.func.isRequired,
   onChangeMemorableDay: PropTypes.func.isRequired,

--- a/frontend/src/components/presentations/PostDialog.jsx
+++ b/frontend/src/components/presentations/PostDialog.jsx
@@ -9,19 +9,37 @@ import {
   Avatar,
   FormControl,
   FormLabel,
-  Button,
+  TextField,
+  IconButton,
   Checkbox,
   Badge,
+  Paper,
 } from "@mui/material";
+import EventIcon from '@mui/icons-material/Event';
+import WhereToVoteIcon from '@mui/icons-material/WhereToVote';
+import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
+import SendIcon from '@mui/icons-material/Send';
 import PropTypes from 'prop-types';
+
+import ChatIcon from '@mui/icons-material/Chat';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+// import AccordionActions from '@mui/material/AccordionActions';
+
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
 import styled from "styled-components";
 import { PostLocationMap } from "./PostLocationMap.jsx";
+// import { PostReplies } from "./PostReplies.jsx";
+import { PostReply } from "./PostReply.jsx";
 
-const TagWrapper = styled.span`
+const ItemWrapper = styled.span`
   background-color: #e8f8f8;
   border: solid;
   border-radius: 50% 20% / 10% 40%;
@@ -34,18 +52,32 @@ export const PostDialog = ({
   post,
   postImages,
   user,
+  userList,
+  loginUser,
   map,
   tags,
   favoriteState,
   favoritesCount,
   bookmarkState,
+  replyText,
+  replies,
+  repliesCount,
   message,
   onClose,
   onClickFavorite,
   onClickBookmark,
+  onChangeReply,
+  onClickReplyCreate,
+  onClickReplyDelete,
   onClickPostEdit,
   onClickPostDelete,
   }) => {
+
+  // 投稿投稿へのreplyのみ取得する．
+  const postReplies = replies.filter((reply) =>
+    reply.post_id === post.id
+  );
+
   return (
     <Dialog open={isOpen} onClose={onClose}>
       {message &&
@@ -54,59 +86,59 @@ export const PostDialog = ({
         </Stack>
       }
       <DialogTitle>
-        {user &&
-          <Stack direction="row">
-          <Avatar alt={user.user_name} src={user.user_avatar} style={{marginRight: "10px"}} />
-          {user.user_name}
-        </Stack>}
+        <Stack direction="row">
+          {user &&
+            <Stack direction="row">
+              <Avatar alt={user.user_name} src={user.user_avatar} style={{marginRight: "10px"}} />
+              {user.user_name}
+            </Stack>
+          }
+        </Stack>
       </DialogTitle>
       <DialogContent>
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>コメント</FormLabel>
-            {post.comment}
-          </FormControl>
-        </div>
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>どこ？</FormLabel>
-            {map.location && map.location}
-          </FormControl>
-        </div>
+        <FormControl margin="normal">
+          <FormLabel>コメント</FormLabel>
+          {post.comment}
+        </FormControl>
         {map.latitude && <PostLocationMap map={map} />}
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>画像</FormLabel>
-            <span>
-              {postImages &&
-                postImages.map((image) =>
-                  <span key={image.id}>
-                    <img alt="post_images" src={image} height="100" style={{ marginRight: "10px"}} />
-                  </span>
-                )
-              }
+        <FormControl margin="normal">
+          <span>
+            {postImages &&
+              postImages.map((image) =>
+                <span key={image.id}>
+                  <img alt="post_images" src={image} height="100" style={{ marginRight: "10px"}} />
+                </span>
+              )
+            }
+          </span>
+        </FormControl>
+        <FormControl margin="normal">
+          <Stack direction="row">
+            <EventIcon />
+            <span>いつ？
+              <ItemWrapper>
+                {post.memorized_on ? `${post.memorized_on}`.slice(0, 14) : "unknown"}
+              </ItemWrapper>
             </span>
-          </FormControl>
-        </div>
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>いつ？</FormLabel>
-            {post.memorized_on}
-          </FormControl>
-        </div>
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>タグ</FormLabel>
-            <span>
-              {tags.map((tag) =>
-                tag &&
-                <TagWrapper key={tag.id}>
-                  {tag.tag_name}
-                </TagWrapper>
-              )}
+            <WhereToVoteIcon />
+            <span>どこ？
+              <ItemWrapper>
+                {map.location ? map.location : "unknown"}
+              </ItemWrapper>
             </span>
-          </FormControl>
-        </div>
+          </Stack>
+        </FormControl>
+        <Stack direction="row">
+          <LocalOfferIcon />タグ
+          <span>
+            {tags.map((tag) =>
+              tag &&
+              <ItemWrapper key={tag.id}>
+                {tag.tag_name}
+              </ItemWrapper>
+            )}
+          </span>
+        </Stack>
         <div>
           <FormControl margin="normal">
             <FormLabel>公開先グループ（グループアイコンとグループ名）</FormLabel>
@@ -137,12 +169,6 @@ export const PostDialog = ({
             {`${post.updated_at}`.slice(0, 10)}
           </FormControl>
         </div>
-        <div>
-          <FormControl margin="normal">
-            <FormLabel>リプライ</FormLabel>
-            {/* {user.user_profile} */}
-          </FormControl>
-        </div>
       </DialogContent>
       <DialogActions>
         <Badge badgeContent={favoritesCount} color="secondary">
@@ -159,20 +185,82 @@ export const PostDialog = ({
           checked={bookmarkState}
           onChange={onClickBookmark}
         />
-        <Button
-          startIcon={<DeleteIcon />}
+        <IconButton
+          // startIcon={<DeleteIcon />}
           onClick={onClickPostDelete}
         >
-          削除する
-        </Button>
-        <Button
+          {/* 削除する */}
+          <DeleteIcon />
+        </IconButton>
+        <IconButton
           variant="outlined"
-          startIcon={<EditIcon />}
+          // startIcon={<EditIcon />}
           onClick={onClickPostEdit}
           aria-hidden="true"
         >
-          編集する
-        </Button>
+          <EditIcon />
+          {/* 編集する */}
+        </IconButton>
+      </DialogActions>
+      <DialogActions>
+        <FormControl fullWidth margin="none">
+          <Accordion elevation={5}>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="panel1a-content"
+              id="panel1a-header"
+            >
+              {repliesCount > 0 ?
+                <Badge badgeContent={repliesCount} color="secondary">
+                  <ChatIcon  style={{color: "green"}}  />
+                </Badge>
+              :
+                <ChatIcon />
+              }
+              <Typography>__投稿にコメントしよう！</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Stack direction="row">
+                <TextField
+                  onChange={onChangeReply}
+                  label="コメントしよう！"
+                  type="text"
+                  value={replyText}
+                  multiline
+                  fullWidth
+                  variant="standard"
+                  margin="normal"
+                />
+                <IconButton
+                  type="submit"
+                  onClick={onClickReplyCreate}
+                  variant="standard"
+                >
+                  <SendIcon />
+                </IconButton>
+              </Stack>
+              <Paper>
+                {postReplies &&
+                  postReplies.map((reply) => {
+                    // 投稿者を取得する．
+                    const replyUser = userList.get(reply.user_id);
+
+                    return (
+                      <div key={reply.id}>
+                        <PostReply
+                          replyUser={replyUser}
+                          loginUser={loginUser}
+                          reply={reply}
+                          onClickReplyDelete={onClickReplyDelete}
+                        />
+                      </div>
+                    )
+                  })
+                }
+              </Paper>
+            </AccordionDetails>
+          </Accordion>
+        </FormControl>
       </DialogActions>
     </Dialog>
   )
@@ -195,6 +283,8 @@ PostDialog.propTypes = {
       user_avatar: PropTypes.string.isRequired,
     })
   ).isRequired,
+  userList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  loginUser: PropTypes.objectOf(PropTypes.string).isRequired,
   map: PropTypes.objectOf(
     PropTypes.shape({
       location: PropTypes.string.isRequired,
@@ -213,10 +303,16 @@ PostDialog.propTypes = {
   favoriteState: PropTypes.bool.isRequired,
   favoritesCount: PropTypes.number.isRequired,
   bookmarkState: PropTypes.bool.isRequired,
+  replyText: PropTypes.string.isRequired,
+  replies: PropTypes.arrayOf(PropTypes.string).isRequired,
+  repliesCount: PropTypes.number.isRequired,
   message: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
   onClickFavorite: PropTypes.func.isRequired,
   onClickBookmark: PropTypes.func.isRequired,
+  onChangeReply: PropTypes.func.isRequired,
+  onClickReplyCreate: PropTypes.func.isRequired,
+  onClickReplyDelete: PropTypes.func.isRequired,
   onClickPostEdit: PropTypes.func.isRequired,
   onClickPostDelete: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/presentations/PostReply.jsx
+++ b/frontend/src/components/presentations/PostReply.jsx
@@ -1,0 +1,81 @@
+import React, { memo } from 'react';
+import {
+  Stack,
+  FormControl,
+  Checkbox,
+  Avatar,
+} from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const LoginUserReplyWrapper = styled.div`
+  background-color: #BAD3FF;
+  border: solid;
+  border-radius: 10px;
+  margin: 3px 10px;
+  padding: 0 5px 10px;
+  max-width: 60%;
+`;
+
+const OtherUsersReplyWrapper = styled.div`
+  background-color: #EEEEEE;
+  border: solid;
+  border-radius: 10px;
+  margin: 3px 10px;
+  padding: 0 5px 10px;
+  max-width: 60%;
+`;
+
+export const PostReply = memo(({
+  replyUser,
+  loginUser,
+  reply,
+  onClickReplyDelete,
+  }) => {
+  return (
+    replyUser.id === loginUser.id ?
+      // ログインユーザーのコメントは右に寄せる.
+      <>
+        <Stack direction="row" justifyContent="flex-end">
+          <Avatar alt={replyUser.user_name} src={replyUser.user_avatar} style={{marginRight: "10px"}} />
+          {replyUser.user_name}
+          <Checkbox
+            icon={<DeleteIcon />}
+            checkedIcon={<DeleteIcon style={{color: "blue"}} />}
+            // checked={bookmarkState}
+            onChange={() => onClickReplyDelete(reply.id)}
+          />
+        </Stack>
+        <Stack direction="row" justifyContent="flex-end">
+          <LoginUserReplyWrapper>
+            <FormControl margin="normal">
+              {reply.reply}
+            </FormControl>
+          </LoginUserReplyWrapper>
+        </Stack>
+      </>
+    :
+      // その他ユーザーのコメントは左に寄せる
+      <>
+        <Stack direction="row">
+          <Avatar alt={replyUser.user_name} src={replyUser.user_avatar} style={{marginRight: "10px"}} />
+          {replyUser.user_name}
+        </Stack>
+        <Stack direction="row">
+          <OtherUsersReplyWrapper>
+            <FormControl margin="normal">
+              {reply.reply}
+            </FormControl>
+          </OtherUsersReplyWrapper>
+        </Stack>
+      </>
+  )
+});
+
+PostReply.propTypes = {
+  replyUser: PropTypes.objectOf(PropTypes.string).isRequired,
+  loginUser: PropTypes.arrayOf(PropTypes.string).isRequired,
+  reply: PropTypes.objectOf(PropTypes.string).isRequired,
+  onClickReplyDelete: PropTypes.func.isRequired,
+};

--- a/frontend/src/reducers/posts.js
+++ b/frontend/src/reducers/posts.js
@@ -19,6 +19,7 @@ export const initialFaviconsState = {
   favoriteList: [],
   favoriteListAll: [],
   bookmarkList: [],
+  replyList: [],
 };
 
 export const postsReducer = (state, action) => {
@@ -55,6 +56,7 @@ export const faviconsReducer = (state, action) => {
         favoriteList: action.payload.favorites,
         favoriteListAll: action.payload.favoritesAll,
         bookmarkList: action.payload.bookmarks,
+        replyList: action.payload.replies,
       };
     default:
       throw new Error();

--- a/frontend/src/urls/index.js
+++ b/frontend/src/urls/index.js
@@ -17,3 +17,9 @@ export const favorites = (postId) =>
 
 export const bookmarks = (postId) =>
   `${DEFAULT_API_LOCALHOST}/posts/${postId}/bookmarks`;
+
+export const replies = (postId) =>
+  `${DEFAULT_API_LOCALHOST}/posts/${postId}/replies`;
+
+export const reply = (postId, replyId) =>
+  `${DEFAULT_API_LOCALHOST}/posts/${postId}/replies/${replyId}`;


### PR DESCRIPTION
## 概要

投稿へのreply機能を実装する．

## 目的

グループで思い出を共有し，コミュニケーションを取れるようにする．

## 設計，実装タスク

設計：

- [ ]  投稿詳細モーダルにリプライ欄を設ける．
    
    [[『React』 +『Redux』 + 『Firebase』でLINE風のChat機能を作ろう！ 【Component編】 - Qiita](https://qiita.com/micropig3402/items/3431c998df582a441fa5)](https://qiita.com/micropig3402/items/3431c998df582a441fa5)
    
    - [ ]  アコーディオン設定．
    - [ ]  コメント入力フォーム，送信ボタン
    - [ ]  投稿後，入力フォームを空にする．
    - [ ]  投稿にはユーザーアイコン，ユーザーネームをつける
    - [ ]  自分の投稿・アバターは右寄せ
    - [ ]  他人の投稿・アバターは左寄せ
    - [ ]  投稿日時
    - [ ]  削除ボタンを実装．（ログインユーザーのみ）
    - [ ]  コメント表示はmax幅60%ぐらいにする．文字数に応じて幅を変える．
    - [ ]  コメント入力後，削除後にホームページがリロードされないようにする．じゃけえのudemyで似たようなのあったな！
- [ ]  投稿一覧のカードにchatアイコンを表示．
- [ ]  chatアイコンにコメント数をバッジで記載する．favoriteと同じ．
- [ ]  コメントがあればアイコンの色をつける．favoriteと同じ．

タスク：

- [ ]  コントローラ：
    - [ ]  posts_controller.rb
        - [ ]  replyレコードをレンダリングする．
    - [ ]  replies_controller.rb
        - [ ]  jsonデータでリプライ生成，削除のメッセージをレンダリングする．
- [ ]  コンテナ：Posts.jsx
    - [ ]  Reducerの設定
        - [ ]  ステート定義：既存のfetchfaviconListにreplies追加するため今回不要．
        - [ ]  関数定義：同上．
    - [ ]  api通信の設定　CRUD
        - [ ]  fetch：postsコントローラから既存replyのレコードを取得．fetchPostListにreplies追加．
        - [ ]  post：入力したメッセージをRailsに送信しcreate．
        - [ ]  put：不要
        - [ ]  delete：対象情報ををRailsに送信しdestroy.
    - [ ]  Stateを設定．
        - [ ]  reply
    - [ ]  new Map()の設定（投稿一覧や投稿詳細にデータをpropsで渡すためのデータベースとなるオブジェクト．オブジェクトにキーを設定し，適宜取り出しpropsに渡す．）**new Map()はオブジェクトを返す！**
        - [ ]  既存のpostUserMapを利用．
    - [ ]  new FormData()の設定（create, updateでデータをサーバーに送信するための設定）
        - [ ]  replyを追加．
    - [ ]  propsの設定
        - [ ]  値
            - [ ]  onChangeReplyでformDataに値を格納．
        - [ ]  イベント
- [ ]  プレゼンテーション：PostsIndex.jsx
    - [ ]  replyのchat欄を作成．
    - [ ]  propsの受け取り
    - [ ]  propsの型定義
- [ ]  urls/index.js：replies_controller.rbのアクションを実行するためのurlを追加．
- [ ]  api/posts.js：reply追加，削除のためのpost, deleteメソッドを新設．
- [ ]  reducers/posts.js：faviconsReducerにreplyListを追加．