### PR TITLE
【React 機能実装】画像ギャラリーをモーダル表示

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "arrow-body-style": "off",
     "react/function-component-definition": "off",
     "react/no-array-index-key": "off",
+    "no-nested-ternary": "off",
   },
   settings: { "import/resolver": "webpack" },
 };

--- a/frontend/src/components/containers/Posts.jsx
+++ b/frontend/src/components/containers/Posts.jsx
@@ -5,11 +5,11 @@ import {
   Alert,
   Button,
 } from '@mui/material';
+import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
 import { fetchPosts, postPost, putPost, deletePost } from "../../apis/posts";
 import { postFavorite, deleteFavorite } from "../../apis/favorites";
 import { postBookmark, deleteBookmark } from "../../apis/bookmarks";
 import { postReply, deleteReply } from "../../apis/replies";
-
 import { REQUEST_STATE } from "../../constants";
 import {
   actionTypes,
@@ -28,6 +28,7 @@ import { PostCreateDialog } from '../presentations/PostCreateDialog.jsx';
 import { PostEditDialog } from '../presentations/PostEditDialog.jsx';
 import { PostDialog } from '../presentations/PostDialog.jsx';
 import { CircularIndeterminate } from '../presentations/CircularIndeterminate.jsx';
+import { PostImageGalleryDialog } from '../presentations/PostImageGalleryDialog.jsx';
 
 export const Posts = memo(() => {
   const {
@@ -46,6 +47,7 @@ export const Posts = memo(() => {
   const [faviconsState, faviconsDispatch] = useReducer(faviconsReducer, initialFaviconsState);
   const [postState, setPostState] = useState({
     isHomePage: true,
+    isOpenPostImageGalleryDialog: false,
     isOpenPostCreateDialog: false,
     isOpenPostDialog: false,
     isOpenPostEditDialog: false,
@@ -432,11 +434,23 @@ export const Posts = memo(() => {
           >
             新規投稿する
           </Button>
+          <Button
+            variant="outlined"
+            startIcon={<PhotoLibraryIcon />}
+            onClick={() =>
+              setPostState({
+                ...postState,
+                isOpenPostImageGalleryDialog: true,
+                message: null,
+              })
+            }
+          >
+            ギャラリーを開く
+          </Button>
           {/* GoogleMap */}
           {postsState.mapList.length > 0 &&
             <LocationsMap maps={postsState.mapList} />
           }
-          {/* <LocationsMap googleMapsApiKey={googleMapsApiKey} /> */}
           {/* 投稿一覧 */}
           <Container>
             <Grid
@@ -503,6 +517,55 @@ export const Posts = memo(() => {
             </Grid>
           </Container>
         </>
+      }
+
+      {/* 画像一覧モーダル */}
+      {
+        postState.isOpenPostImageGalleryDialog &&
+        <PostImageGalleryDialog
+          isOpen={postState.isOpenPostImageGalleryDialog}
+          // post={postState.selectedPost}
+          // postImages={postState.selectedPost.post_images}
+          postList={postsState.postList}
+          // user={userState.selectedUser}
+          mapList={postMapMap}
+          userList={postUserMap}
+          onClose={() => {
+            setPostState({
+              ...postState,
+              isOpenPostImageGalleryDialog: false,
+            })
+          }}
+          onClickPost={(post) => {
+            setPostState({
+              ...postState,
+              isOpenPostDialog: true,
+              selectedPost: post,
+              message: null,
+            })
+            // setPostImages(post.post_images)
+            setUserState({
+              ...userState,
+              selectedUser: postUserMap.get(post.user_id),
+            })
+            setSessionState({
+              ...sessionState,
+              message: null,
+            })
+          }}
+          onClickUser={(user) => {
+            setUserState({
+              ...userState,
+              isOpenUserDialog: true,
+              selectedUser: user,
+              // selectedUser: postUserMap.get(post.user_id),
+            })
+            setSessionState({
+              ...sessionState,
+              message: null,
+            })
+          }}
+        />
       }
 
       {/* ログインモーダル */}

--- a/frontend/src/components/presentations/PostDialog.jsx
+++ b/frontend/src/components/presentations/PostDialog.jsx
@@ -14,6 +14,10 @@ import {
   Checkbox,
   Badge,
   Paper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
 } from "@mui/material";
 import EventIcon from '@mui/icons-material/Event';
 import WhereToVoteIcon from '@mui/icons-material/WhereToVote';
@@ -23,20 +27,11 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
 import SendIcon from '@mui/icons-material/Send';
-import PropTypes from 'prop-types';
-
 import ChatIcon from '@mui/icons-material/Chat';
-import Accordion from '@mui/material/Accordion';
-import AccordionSummary from '@mui/material/AccordionSummary';
-import AccordionDetails from '@mui/material/AccordionDetails';
-// import AccordionActions from '@mui/material/AccordionActions';
-
-import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-
+import PropTypes from 'prop-types';
 import styled from "styled-components";
 import { PostLocationMap } from "./PostLocationMap.jsx";
-// import { PostReplies } from "./PostReplies.jsx";
 import { PostReply } from "./PostReply.jsx";
 
 const ItemWrapper = styled.span`
@@ -242,6 +237,7 @@ export const PostDialog = ({
               <Paper>
                 {postReplies &&
                   postReplies.map((reply) => {
+
                     // 投稿者を取得する．
                     const replyUser = userList.get(reply.user_id);
 

--- a/frontend/src/components/presentations/PostImageGalleryDialog.jsx
+++ b/frontend/src/components/presentations/PostImageGalleryDialog.jsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+// import ImageList from '@mui/material/ImageList';
+// import ImageListItem from '@mui/material/ImageListItem';
+// import ImageListItemBar from '@mui/material/ImageListItemBar';
+// import ListSubheader from '@mui/material/ListSubheader';
+import {
+  useMediaQuery,
+  useTheme,
+  Dialog,
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+  ListSubheader,
+  Avatar,
+  IconButton,
+  // Stack,
+} from "@mui/material";
+import PhotoLibraryIcon from '@mui/icons-material/PhotoLibrary';
+import PropTypes from 'prop-types';
+
+export const PostImageGalleryDialog = ({
+  isOpen,
+  postList,
+  mapList,
+  userList,
+  onClose,
+  onClickPost,
+  onClickUser,
+}) => {
+
+  const theme = useTheme();
+  const matcheDownSm = useMediaQuery(theme.breakpoints.down('sm'));
+  const matcheDownMd = useMediaQuery(theme.breakpoints.down('md'));
+
+  return (
+    <Dialog maxWidth="lg" open={isOpen} onClose={onClose}>
+      <ImageList
+        // sx={{ width: "auto" }}
+        // sx={{ width: "100%" }}
+        // sx={{ width: 1000, height: 1000 }}
+        cols={matcheDownSm ? 2 : matcheDownMd ? 3 : 4}
+        variant="quilted"
+        // rowHeight={121}
+      >
+        <ImageListItem
+          key="Subheader"
+          cols={matcheDownSm ? 2 : matcheDownMd ? 3 : 4}
+        >
+          <ListSubheader sx={{ fontSize: '24px' }}>
+            <IconButton aria-label="PhotoLibraryIcon">
+              <PhotoLibraryIcon fontSize="large" />
+            </IconButton>
+            イメージギャラリー（画像をタップ！）
+          </ListSubheader>
+        </ImageListItem>
+
+        {postList &&
+          postList.map((post) => {
+
+            // 思い出場所，投稿者を取得する．
+            const postMap = mapList.get(post.map_id);
+            const postUser = userList.get(post.user_id);
+
+            return (
+              post.post_images &&
+                post.post_images.map((image, index) => {
+                  return (
+                    <ImageListItem key={index}>
+                      <ImageListItem onClick={() => onClickPost(post)} sx={{ cursor: 'pointer' }}>
+                        <img
+                          src={image}
+                          alt="post_images"
+                          loading="lazy"
+                        />
+                      </ImageListItem>
+                      <ImageListItemBar
+                        title={`${
+                            postMap.location ? postMap.location : "anywhere"
+                          } ${
+                            post.memorized_on ? String(post.memorized_on).slice(0, 10) : "sometime"
+                          }`}
+                        subtitle={postUser.user_name}
+                        actionIcon={
+                          <IconButton
+                            sx={{ color: 'rgba(255, 255, 255, 0.54)' }}
+                            aria-label={`info about ${postUser.user_name} ${index}`}
+                            onClick={() => onClickUser(postUser)}
+                          >
+                            <Avatar alt={postUser.user_name} src={postUser.user_avatar} />
+                          </IconButton>
+                        }
+                      />
+                    </ImageListItem>
+                  )
+                })
+
+            )
+          })
+        }
+
+      </ImageList>
+    </Dialog>
+  );
+};
+
+PostImageGalleryDialog.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  postList: PropTypes.arrayOf(
+    PropTypes.shape({
+      post: PropTypes.objectOf(
+        PropTypes.shape({
+          id: PropTypes.number.isRequired,
+          user_id: PropTypes.string.isRequired,
+          memorized_on: PropTypes.string.isRequired,
+          post_images: PropTypes.string.isRequired,
+        })
+      )
+    })
+  ).isRequired,
+  mapList: PropTypes.objectOf(
+    PropTypes.shape({
+      location: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  userList: PropTypes.objectOf(
+    PropTypes.shape({
+      user_name: PropTypes.string.isRequired,
+      user_avatar: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  onClose: PropTypes.func.isRequired,
+  onClickPost: PropTypes.func.isRequired,
+  onClickUser: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## 概要

思い出を画廊として表示する．

## 目的

画像をキーに投稿を遡れるようにする．UX向上．

## 設計，実装タスク

機能・表示設計

- [ ]  画像一覧表示

[[Image List React component - Material UI](https://mui.com/material-ui/react-image-list/#quilted-image-list)](https://mui.com/material-ui/react-image-list/#quilted-image-list)

- [ ]  画像に投稿者を載せる．
- [ ]  画像タップで投稿詳細モーダルを開く．
    - [ ]  同じサイズの画像リストを生成
    - [ ]  次に動的にサイズが変更される画像リストにする．
    - [ ]  ImageListItemBarにどこ？，いつ？，ユーザーを載せる．ユーザーは小さく．

- [ ]  コントローラ：posts_controller.rb：新設なし．
- [ ]  コンテナ：Posts.jsx
    - [ ]  useStateの設定：画像ギャラリーのモーダル開閉用ステートを新設
- [ ]  プレゼンテーション：PostImageGalleryDialog.jsx
    
    モーダルで作る